### PR TITLE
Make notes page collapsible and grouped by book

### DIFF
--- a/_data/books.yml
+++ b/_data/books.yml
@@ -1,0 +1,22 @@
+# Registry of book note collections shown on the /notes/ page.
+#
+# To add notes for a new book:
+#   1. Add a new collection in `_config.yml` under `collections:` (output: true)
+#      and a matching `defaults` entry, then create a `_<collection>/` folder
+#      with one markdown file per note/chapter.
+#   2. Add an entry below pointing at that collection.
+#
+# Fields:
+#   title      Book title shown in the collapsible header.
+#   author     Author shown next to the title (optional).
+#   collection Name of the Jekyll collection that holds the notes.
+#   sort_by    Front matter field used to order notes (optional).
+#   group_by   Front matter field used to group notes within the book (optional).
+#   open       Whether the section starts expanded (optional, defaults to false).
+
+- title: "Designing Data-Intensive Applications"
+  author: "Martin Kleppmann"
+  collection: ddia
+  sort_by: chapter
+  group_by: part
+  open: true

--- a/_layouts/notes.html
+++ b/_layouts/notes.html
@@ -1,0 +1,43 @@
+---
+layout: archive
+---
+
+{{ content }}
+
+<div class="notes-books">
+  {% for book in site.data.books %}
+    {% assign entries = site[book.collection] | where_exp: "post", "post.hidden != true" %}
+    {% if book.sort_by %}
+      {% assign entries = entries | sort: book.sort_by %}
+    {% endif %}
+
+    <details class="notes-book"{% if book.open %} open{% endif %}>
+      <summary class="notes-book__summary">
+        <span class="notes-book__heading">
+          <span class="notes-book__title">{{ book.title }}</span>
+          {% if book.author %}<span class="notes-book__author">{{ book.author }}</span>{% endif %}
+        </span>
+        <span class="notes-book__count">{{ entries | size }} notes</span>
+        <span class="notes-book__chevron" aria-hidden="true"></span>
+      </summary>
+
+      <div class="notes-book__body">
+        {% assign group_field = book.group_by %}
+        {% assign current_group = "__notes_unset__" %}
+        {% for post in entries %}
+          {% if group_field %}{% assign post_group = post[group_field] %}{% else %}{% assign post_group = "" %}{% endif %}
+          {% if post_group != current_group %}
+            {% unless forloop.first %}</ul>{% endunless %}
+            {% assign current_group = post_group %}
+            {% if post_group and post_group != "" %}<h3 class="notes-book__part">{{ post_group }}</h3>{% endif %}
+            <ul class="notes-book__list">
+          {% endif %}
+          <li class="notes-book__item">
+            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+          </li>
+          {% if forloop.last %}</ul>{% endif %}
+        {% endfor %}
+      </div>
+    </details>
+  {% endfor %}
+</div>

--- a/_pages/notes.md
+++ b/_pages/notes.md
@@ -1,13 +1,11 @@
 ---
 title: "Notes"
 permalink: /notes/
-layout: collection
-collection: ddia
-sort_by: chapter
+layout: notes
 author_profile: true
 classes: wide
 ---
 
-Working through *Designing Data-Intensive Applications* by Martin Kleppmann — a
-chapter-by-chapter set of study notes on the ideas behind reliable, scalable, and
-maintainable data systems.
+Study notes from books I'm working through, organized by book. Expand a title to
+browse the notes — starting with *Designing Data-Intensive Applications* by
+Martin Kleppmann, with more books to come.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -351,6 +351,134 @@ a {
 }
 
 /* ==========================================================================
+   Notes index — collapsible per-book sections
+   ========================================================================== */
+
+.notes-books {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.notes-book {
+  border: 1px solid var(--border);
+  border-radius: $border-radius;
+  background-color: var(--bg-elevated);
+  overflow: hidden;
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+
+  &[open] {
+    box-shadow: var(--shadow-sm);
+  }
+
+  &__summary {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.1rem 1.4rem;
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    &:hover {
+      background-color: var(--bg-subtle);
+    }
+  }
+
+  &__heading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__title {
+    font-size: 1.1rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: var(--text);
+    line-height: 1.3;
+  }
+
+  &__author {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  &__count {
+    font-size: 0.78rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    background-color: var(--bg-subtle);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.15rem 0.6rem;
+    white-space: nowrap;
+  }
+
+  &__chevron {
+    flex: 0 0 auto;
+    width: 0.55rem;
+    height: 0.55rem;
+    border-right: 2px solid var(--text-muted);
+    border-bottom: 2px solid var(--text-muted);
+    transform: rotate(45deg);
+    transition: transform 0.2s ease;
+  }
+
+  &[open] &__chevron {
+    transform: rotate(-135deg);
+  }
+
+  &__body {
+    padding: 0.25rem 1.4rem 1.1rem;
+    border-top: 1px solid var(--border);
+  }
+
+  &__part {
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    margin: 1.1rem 0 0.5rem;
+  }
+
+  &__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  &__item {
+    margin: 0;
+
+    a {
+      display: block;
+      padding: 0.5rem 0.7rem;
+      margin: 0 -0.7rem;
+      border-radius: 8px;
+      color: var(--text);
+      font-weight: 500;
+      text-decoration: none;
+      line-height: 1.4;
+      transition: background-color 0.16s ease, color 0.16s ease;
+
+      &:hover {
+        background-color: var(--bg-subtle);
+        color: var(--accent);
+        text-decoration: none;
+      }
+    }
+  }
+}
+
+/* ==========================================================================
    Article / page content
    ========================================================================== */
 
@@ -657,6 +785,22 @@ a {
   .entries-list .list__item .archive__item {
     background-color: var(--bg-elevated);
     border-color: var(--border);
+  }
+
+  .notes-book {
+    background-color: var(--bg-elevated);
+    border-color: var(--border);
+
+    &__title { color: var(--text); }
+    &__author,
+    &__count { color: var(--text-muted); }
+    &__count { background-color: var(--bg-subtle); border-color: var(--border); }
+    &__body { border-top-color: var(--border); }
+
+    &__item a {
+      color: var(--text);
+      &:hover { background-color: var(--bg-subtle); color: var(--accent); }
+    }
   }
 
   .btn-pill--ghost {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks the `/notes/` page so notes are organized **by book** inside **collapsible sections**, ready for notes from multiple books. Currently all notes belong to *Designing Data-Intensive Applications*; new books can be added without editing any layouts.

## What changed

- **`_data/books.yml`** (new): a small registry mapping each book to its Jekyll collection, with `title`, `author`, `sort_by`, `group_by`, and `open` (start expanded) fields. Adding a new book is just a new collection + one entry here.
- **`_layouts/notes.html`** (new): renders each book as a native `<details>`/`<summary>` collapsible. Inside each book, notes are listed and optionally grouped (DDIA is grouped by `part`). Shows a note count and an animated chevron.
- **`_pages/notes.md`**: switched from `layout: collection` to the new `layout: notes`; updated intro copy to reflect the multi-book, expandable layout.
- **`assets/css/main.scss`**: styling for the collapsible book sections (cards, hover states, chevron rotation, part headers) plus matching dark-mode overrides.

## How to add another book later

1. Add a collection in `_config.yml` (`output: true`) with a matching `defaults` entry and a `_<collection>/` folder of markdown notes.
2. Add an entry to `_data/books.yml` pointing at that collection.

## Verification

Built locally with Jekyll. The notes page renders one collapsible DDIA section (expanded by default), reporting 12 notes grouped into the three book parts, with chapters correctly ordered and linked. The custom SCSS compiles into `main.css`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71ffb45b-b38a-4730-a107-65d4c4c49118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71ffb45b-b38a-4730-a107-65d4c4c49118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

