### PR TITLE
Restyle site to a minimal, monochrome look

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,30 +11,30 @@
    the skin's `!default` values)
    ========================================================================== */
 
-/* Light theme */
+/* Light theme — minimal neutral palette (headless-commerce inspired) */
 $background-color: #ffffff;
-$text-color: #1f2328;
-$muted-text-color: #57606a;
-$primary-color: #4f46e5;
-$border-color: #e6e8eb;
-$code-background-color: #f6f8fa;
-$code-background-color-dark: #eaeef2;
-$form-background-color: #f6f8fa;
+$text-color: #171717;
+$muted-text-color: #6b7280;
+$primary-color: #171717;
+$border-color: #e5e5e5;
+$code-background-color: #f5f5f5;
+$code-background-color-dark: #ededed;
+$form-background-color: #fafafa;
 $footer-background-color: #fafafa;
 
-$link-color: #4338ca;
-$link-color-hover: #3730a3;
-$link-color-visited: #4338ca;
+$link-color: #171717;
+$link-color-hover: #000000;
+$link-color-visited: #171717;
 $masthead-link-color: $text-color;
-$masthead-link-color-hover: $primary-color;
+$masthead-link-color-hover: #000000;
 
 /* Typography */
 $global-font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
   "Helvetica Neue", Arial, sans-serif;
 $header-font-family: $global-font-family;
 
-/* Shape */
-$border-radius: 10px;
+/* Shape — flatter, more minimal */
+$border-radius: 6px;
 
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}";
 @import "minimal-mistakes";
@@ -46,14 +46,14 @@ $border-radius: 10px;
 :root {
   --bg: #{$background-color};
   --bg-elevated: #ffffff;
-  --bg-subtle: #f6f8fa;
+  --bg-subtle: #fafafa;
   --text: #{$text-color};
   --text-muted: #{$muted-text-color};
   --border: #{$border-color};
   --accent: #{$primary-color};
-  --accent-strong: #4338ca;
-  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06), 0 1px 3px rgba(15, 23, 42, 0.08);
-  --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.08), 0 2px 4px rgba(15, 23, 42, 0.05);
+  --accent-strong: #000000;
+  --shadow-sm: none;
+  --shadow-md: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
 /* ==========================================================================
@@ -68,11 +68,11 @@ body {
 
 ::selection {
   background-color: var(--accent);
-  color: #fff;
+  color: var(--bg);
 }
 ::-moz-selection {
   background-color: var(--accent);
-  color: #fff;
+  color: var(--bg);
 }
 
 a {
@@ -94,18 +94,18 @@ a {
   background: transparent;
 
   .site-title {
-    font-weight: 700;
-    letter-spacing: -0.02em;
+    font-weight: 600;
+    letter-spacing: -0.01em;
   }
 
   a {
-    font-weight: 500;
+    font-weight: 450;
   }
 
   .visible-links a:before {
-    height: 3px;
+    height: 2px;
     background: var(--accent);
-    border-radius: 3px;
+    border-radius: 2px;
   }
 }
 
@@ -121,16 +121,15 @@ a {
 
 .author__avatar img {
   border-radius: 50% !important;
-  width: 120px !important;
-  height: 120px !important;
+  width: 110px !important;
+  height: 110px !important;
   object-fit: cover !important;
-  box-shadow: var(--shadow-md);
-  border: 3px solid var(--bg-elevated);
+  border: 1px solid var(--border);
 }
 
 .author__name {
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-weight: 600;
+  letter-spacing: -0.01em;
 }
 
 .author__bio {
@@ -156,72 +155,69 @@ a {
    ========================================================================== */
 
 .home-hero {
-  margin: 1.5rem 0 2.5rem;
+  margin: 1.5rem 0 2.25rem;
 
   &__greeting {
-    font-size: 2.4rem;
-    line-height: 1.1;
-    font-weight: 800;
-    letter-spacing: -0.03em;
+    font-size: 1.6rem;
+    line-height: 1.25;
+    font-weight: 600;
+    letter-spacing: -0.02em;
     color: var(--text);
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4rem;
   }
 
   &__tagline {
-    font-size: 1.15rem;
+    font-size: 0.95rem;
     color: var(--text-muted);
-    margin: 0 0 1.25rem;
-    font-weight: 500;
+    margin: 0 0 1rem;
+    font-weight: 400;
   }
 
   &__intro {
-    font-size: 1.05rem;
+    font-size: 0.95rem;
     line-height: 1.7;
-    color: var(--text);
-    max-width: 46rem;
-    margin: 0 0 1.5rem;
+    color: var(--text-muted);
+    max-width: 44rem;
+    margin: 0 0 1.25rem;
   }
 
   &__actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.6rem;
+    gap: 0.5rem;
   }
 }
 
 .btn-pill {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.55rem 1.1rem;
-  border-radius: 999px;
-  font-size: 0.95rem;
-  font-weight: 600;
+  gap: 0.4rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: $border-radius;
+  font-size: 0.875rem;
+  font-weight: 500;
   text-decoration: none !important;
-  transition: transform 0.15s ease, box-shadow 0.18s ease,
-    background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+  border: 1px solid transparent;
+  transition: background-color 0.15s ease, border-color 0.15s ease,
+    color 0.15s ease;
 
   &--primary {
     background-color: var(--accent);
-    color: #fff !important;
-    box-shadow: var(--shadow-sm);
+    color: var(--bg) !important;
 
     &:hover {
       background-color: var(--accent-strong);
-      transform: translateY(-1px);
-      box-shadow: var(--shadow-md);
     }
   }
 
   &--ghost {
     background-color: transparent;
     color: var(--text) !important;
-    border: 1px solid var(--border);
+    border-color: var(--border);
 
     &:hover {
-      border-color: var(--accent);
-      color: var(--accent) !important;
-      transform: translateY(-1px);
+      border-color: var(--text);
+      color: var(--text) !important;
     }
   }
 }
@@ -230,22 +226,22 @@ a {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  margin: 2.5rem 0 1.25rem;
-  padding-bottom: 0.6rem;
+  margin: 2.25rem 0 1rem;
+  padding-bottom: 0.5rem;
   border-bottom: 1px solid var(--border);
 
   h2 {
-    font-size: 1.35rem;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     margin: 0;
     border: 0;
     padding: 0;
   }
 
   a {
-    font-size: 0.9rem;
-    font-weight: 600;
+    font-size: 0.85rem;
+    font-weight: 500;
     white-space: nowrap;
   }
 }
@@ -253,45 +249,44 @@ a {
 /* Post list / cards */
 .post-cards {
   display: grid;
-  gap: 1rem;
+  gap: 0.5rem;
 }
 
 .post-card {
   display: block;
-  padding: 1.25rem 1.4rem;
+  padding: 1rem 1.1rem;
   border: 1px solid var(--border);
   border-radius: $border-radius;
   background-color: var(--bg-elevated);
   text-decoration: none !important;
   color: inherit;
-  transition: transform 0.16s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
 
   &:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-md);
-    border-color: rgba(#4f46e5, 0.4);
+    border-color: var(--text);
+    background-color: var(--bg-subtle);
   }
 
   &__title {
-    font-size: 1.15rem;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--text);
-    margin: 0 0 0.35rem;
-    line-height: 1.35;
+    margin: 0 0 0.3rem;
+    line-height: 1.4;
   }
 
   &__meta {
-    font-size: 0.82rem;
+    font-size: 0.8rem;
     color: var(--text-muted);
-    margin: 0 0 0.5rem;
+    margin: 0 0 0.4rem;
     display: flex;
     flex-wrap: wrap;
     gap: 0.75rem;
   }
 
   &__excerpt {
-    font-size: 0.95rem;
+    font-size: 0.9rem;
     line-height: 1.6;
     color: var(--text-muted);
     margin: 0;
@@ -304,8 +299,8 @@ a {
 
 .archive__item-title a {
   color: var(--text) !important;
-  font-weight: 700;
-  letter-spacing: -0.02em;
+  font-weight: 600;
+  letter-spacing: -0.01em;
   text-decoration: none;
 
   &:hover {
@@ -315,18 +310,18 @@ a {
 }
 
 .entries-list .list__item {
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 
   .archive__item {
-    padding: 1.2rem 1.4rem;
+    padding: 1rem 1.1rem;
     border: 1px solid var(--border);
     border-radius: $border-radius;
     background-color: var(--bg-elevated);
-    transition: transform 0.16s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    transition: border-color 0.15s ease, background-color 0.15s ease;
 
     &:hover {
-      transform: translateY(-2px);
-      box-shadow: var(--shadow-md);
+      border-color: var(--text);
+      background-color: var(--bg-subtle);
     }
   }
 
@@ -365,10 +360,10 @@ a {
   border-radius: $border-radius;
   background-color: var(--bg-elevated);
   overflow: hidden;
-  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  transition: border-color 0.2s ease;
 
   &[open] {
-    box-shadow: var(--shadow-sm);
+    border-color: var(--text);
   }
 
   &__summary {
@@ -398,15 +393,15 @@ a {
   }
 
   &__title {
-    font-size: 1.1rem;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--text);
-    line-height: 1.3;
+    line-height: 1.35;
   }
 
   &__author {
-    font-size: 0.85rem;
+    font-size: 0.8rem;
     color: var(--text-muted);
   }
 
@@ -483,7 +478,10 @@ a {
    ========================================================================== */
 
 .page__title {
-  letter-spacing: -0.03em;
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.3;
 
   a {
     color: var(--text);
@@ -492,11 +490,11 @@ a {
 }
 
 .page__content {
-  font-size: 1.02rem;
+  font-size: 0.98rem;
   line-height: 1.75;
 
   code {
-    border-radius: 5px;
+    border-radius: 4px;
   }
 }
 
@@ -504,38 +502,38 @@ a {
    so listing components keep their own typography). */
 .layout--single .page__content {
   h2 {
-    margin-top: 2em;
-    margin-bottom: 0.6em;
-    padding-bottom: 0.3em;
+    margin-top: 1.8em;
+    margin-bottom: 0.5em;
+    padding-bottom: 0.25em;
     border-bottom: 1px solid var(--border);
-    font-size: 1.5em;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+    font-size: 1.3em;
+    font-weight: 600;
+    letter-spacing: -0.01em;
     color: var(--text);
   }
 
   h3 {
     margin-top: 1.4em;
     margin-bottom: 0.4em;
-    font-size: 1.2em;
-    font-weight: 700;
+    font-size: 1.1em;
+    font-weight: 600;
     color: var(--text);
   }
 
   a {
     text-decoration: none;
-    border-bottom: 1px solid rgba(#4f46e5, 0.35);
+    border-bottom: 1px solid var(--border);
 
     &:hover {
-      border-bottom-color: var(--accent);
+      border-bottom-color: var(--text);
     }
   }
 
   blockquote {
-    border-left: 4px solid var(--accent);
+    border-left: 3px solid var(--border);
     background-color: var(--bg-subtle);
     border-radius: 0 $border-radius $border-radius 0;
-    padding: 0.6em 1.1em;
+    padding: 0.5em 1em;
     color: var(--text-muted);
     font-style: normal;
   }
@@ -554,8 +552,8 @@ a {
   h4 {
     margin-bottom: 1rem;
     color: var(--text);
-    font-size: 1.2rem;
-    font-weight: 700;
+    font-size: 1.05rem;
+    font-weight: 600;
   }
 }
 
@@ -634,7 +632,7 @@ a {
     }
 
     .page__title {
-      font-size: 1.8rem !important;
+      font-size: 1.4rem !important;
       line-height: 1.3 !important;
     }
   }
@@ -702,7 +700,7 @@ a {
 
 @media (max-width: 768px) {
   .home-hero__greeting {
-    font-size: 2rem;
+    font-size: 1.4rem;
   }
 
   .section-heading {
@@ -718,16 +716,16 @@ a {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --bg: #0d1117;
-    --bg-elevated: #161b22;
-    --bg-subtle: #161b22;
-    --text: #e6edf3;
-    --text-muted: #9198a1;
-    --border: #2a313c;
-    --accent: #8b93f8;
-    --accent-strong: #a5acff;
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
-    --shadow-md: 0 6px 18px rgba(0, 0, 0, 0.45);
+    --bg: #0a0a0a;
+    --bg-elevated: #131313;
+    --bg-subtle: #171717;
+    --text: #ededed;
+    --text-muted: #a3a3a3;
+    --border: #262626;
+    --accent: #ededed;
+    --accent-strong: #ffffff;
+    --shadow-sm: none;
+    --shadow-md: 0 1px 2px rgba(0, 0, 0, 0.4);
   }
 
   body {
@@ -736,7 +734,7 @@ a {
   }
 
   .masthead {
-    background-color: rgba(13, 17, 23, 0.82);
+    background-color: rgba(10, 10, 10, 0.82);
     border-bottom-color: var(--border);
   }
 
@@ -825,8 +823,8 @@ a {
     a { color: var(--accent); }
 
     code {
-      background-color: #1b2230;
-      color: #e6edf3;
+      background-color: #1f1f1f;
+      color: #ededed;
     }
   }
 
@@ -835,7 +833,7 @@ a {
   .page__related { border-top-color: var(--border); }
 
   .page__footer {
-    background-color: #0a0d12;
+    background-color: #050505;
     border-top-color: var(--border);
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks the site styling toward a more minimal aesthetic, taking color inspiration from headless-commerce storefronts (clean white background, near-black text, subtle neutral gray borders). Replaces the previous indigo/purple accent, big bold headings, and heavy framed cards.

All changes live in `assets/css/main.scss`.

## What changed

**Colors (minimal neutral / monochrome palette)**
- Accent goes from indigo `#4f46e5` to neutral near-black `#171717` (used for primary buttons, links, hover states).
- Borders lightened to `#e5e5e5`, subtle surfaces to `#fafafa`, text to `#171717`, muted text to `#6b7280`.
- Dark mode tokens updated to a matching neutral palette (`#0a0a0a` bg, `#ededed` text, `#262626` borders, near-white accent), with fixed contrast on primary buttons and text selection.

**Smaller letters**
- Home hero heading: `2.4rem`/800 → `1.6rem`/600.
- Article/page titles: explicit `1.6rem`/600 (down from the theme's large default).
- Section headings, card titles, notes-book titles, related-posts heading, and article `h2`/`h3` all reduced in size and weight.

**Flatter, lighter frames**
- Border radius `10px` → `6px`.
- Removed heavy box-shadows and `translateY` hover-lift; cards now use a simple border-color + subtle background change on hover.
- Pill buttons → flatter rounded buttons; lighter avatar border (3px shadowed → 1px).

## Verification
- Custom SCSS compiles cleanly with dart-sass (theme imports unchanged from the prior working build); confirmed the new tokens and type sizes appear in the generated CSS.

## Note
I couldn't locate a public repo named `dns-headless` to copy exact color values from (it may be private/repo-scoped token can't reach it), so I matched the well-established headless-commerce storefront aesthetic: clean monochrome neutrals with black as the primary action color, which fits the requested minimal look. Happy to swap in exact hex values if you share them.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07bb1d3a-b749-45f1-ab4b-c77ecc729b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07bb1d3a-b749-45f1-ab4b-c77ecc729b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

